### PR TITLE
Add search filtering with highlight

### DIFF
--- a/src/Components/SavedPasswords.jsx
+++ b/src/Components/SavedPasswords.jsx
@@ -10,6 +10,7 @@ const SavedPasswords = () => {
   const [password, setPassword] = useState(getNewPassword())
   const [passwordVisible, setPasswordVisible] = useState(false)
   const [passwords, setPasswords] = useState([])
+  const [query, setQuery] = useState('')
 
   useEffect(() => {
     const storedPasswords = JSON.parse(localStorage.getItem('passwords')) || []
@@ -63,9 +64,22 @@ const SavedPasswords = () => {
     setPassword(getNewPassword()) // Reset the password after submission
   }
 
+  const filteredPasswords = passwords.filter(
+    (item) =>
+      item.website.toLowerCase().includes(query.toLowerCase()) ||
+      item.username.toLowerCase().includes(query.toLowerCase())
+  )
+
   return (
     <>
       <div className='w-full max-w-md mx-auto shadow-md rounded-lg px-4 py-3 my-8 bg-gray-800 text-orange-500'>
+        <input
+          type='text'
+          placeholder='Search by website or username'
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className='w-full p-2 mb-4 border rounded'
+        />
         <h2 className='text-2xl font-bold mb-4 text-blue-500'>Save Password</h2>
 
         <form onSubmit={handleSubmit}>
@@ -108,7 +122,7 @@ const SavedPasswords = () => {
           </button>
         </form>
 
-        {<WebsiteList websites={passwords} onDelete={handleDelete} />}
+        {<WebsiteList websites={filteredPasswords} onDelete={handleDelete} searchTerm={query} />}
       </div>
     </>
   )

--- a/src/Components/WebsiteList.jsx
+++ b/src/Components/WebsiteList.jsx
@@ -1,8 +1,22 @@
 import React from 'react'
 
-const WebsiteList = ({ websites, onDelete }) => {
+const WebsiteList = ({ websites, onDelete, searchTerm }) => {
   const handleDelete = (index) => {
     onDelete(index)
+  }
+
+  const highlight = (text) => {
+    if (!searchTerm) return text
+    const regex = new RegExp(`(${searchTerm})`, 'gi')
+    return text.split(regex).map((part, idx) =>
+      regex.test(part) ? (
+        <mark key={idx} className='bg-yellow-200'>
+          {part}
+        </mark>
+      ) : (
+        part
+      )
+    )
   }
 
   return (
@@ -27,13 +41,14 @@ const WebsiteList = ({ websites, onDelete }) => {
               <a
                 href={`http://www.${website.website}.com`}
                 target='_blank'
+                rel='noreferrer'
                 className='text-blue-500 hover:underline'
               >
-                {`www.${website.website}.com`}
+                {highlight(`www.${website.website}.com`)}
               </a>
 
               <div className='text-gray-500 text-sm'>
-                Username: {website.username}
+                Username: {highlight(website.username)}
                 <br />
                 Password: {website.password}
               </div>


### PR DESCRIPTION
## Summary
- enable filtering saved passwords by website or username
- highlight search matches in the WebsiteList output

## Testing
- `npm run lint` *(fails: React unused vars and prop-type warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68435e37a360832494398981264e230b