### PR TITLE
Improve alt text and external link security

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   BrowserRouter as Router,
   Route,

--- a/src/Components/GeneratePassword.jsx
+++ b/src/Components/GeneratePassword.jsx
@@ -1,7 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { setGeneratedPassword, getGeneratedPassword } from './data'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCopy } from '@fortawesome/free-solid-svg-icons'
 
 const GeneratePassword = () => {
   const [length, setLength] = useState(8)

--- a/src/Components/SavedPasswords.jsx
+++ b/src/Components/SavedPasswords.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
-import { getGeneratedPassword, getNewPassword } from './data'
+import { getNewPassword } from './data'
 import WebsiteList from './WebsiteList'
 
 const SavedPasswords = () => {

--- a/src/Components/WebsiteList.jsx
+++ b/src/Components/WebsiteList.jsx
@@ -1,4 +1,5 @@
-import React from 'react'
+
+import PropTypes from 'prop-types'
 
 const WebsiteList = ({ websites, onDelete }) => {
   const handleDelete = (index) => {
@@ -16,7 +17,7 @@ const WebsiteList = ({ websites, onDelete }) => {
           >
             <img
               src={`https://www.${website.website}.com/favicon.ico`}
-              alt=''
+              alt={`${website.website} favicon`}
               onError={(e) => {
                 e.target.src =
                   'https://img.icons8.com/color/48/internet--v1.png'
@@ -27,6 +28,7 @@ const WebsiteList = ({ websites, onDelete }) => {
               <a
                 href={`http://www.${website.website}.com`}
                 target='_blank'
+                rel='noopener noreferrer'
                 className='text-blue-500 hover:underline'
               >
                 {`www.${website.website}.com`}
@@ -49,6 +51,11 @@ const WebsiteList = ({ websites, onDelete }) => {
       </ul>
     </div>
   )
+}
+
+WebsiteList.propTypes = {
+  websites: PropTypes.array.isRequired,
+  onDelete: PropTypes.func.isRequired,
 }
 
 export default WebsiteList


### PR DESCRIPTION
## Summary
- remove unused `React` imports for cleaner linting
- adjust imports in `SavedPasswords` and `GeneratePassword`
- add `PropTypes` definitions in `WebsiteList`
- provide meaningful favicon alt text
- set `rel="noopener noreferrer"` on external links

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68435e247434832495822e9a9a39110a